### PR TITLE
Make the spectrum array values hidden, to avoid junking `set` output

### DIFF
--- a/zsh/functions/spectrum
+++ b/zsh/functions/spectrum
@@ -10,7 +10,7 @@
 # TODO: Degrade gracefully through approximation?
 
 # We define three associative arrays, for effects, foreground colors and background colors.
-typeset -Ag FX FG BG
+typeset -AHg FX FG BG
 
 FX=(
     reset     "[00m"


### PR DESCRIPTION
Hi sykora, here's a suggestion. In `spectrum`, the arrays could have their values hidden. This way, the terminal control codes they contained aren't included in the output of `set`, which will end up messing up the colors and display for the rest of its output. (And making `grep` think it's binary output.)

Enough people are picking up this code that I think it would be nice to include this. I found this while using oh-my-zsh, which uses a fork of this code. (My `set` output has been wonky for months and I finally figured out it was this.) And at least [one StackOverflow answer](http://stackoverflow.com/questions/13869575/how-can-i-define-custom-colors-for-use-in-zsh-prompt) references it.

I've put in a PR for OMZ, too, at robbyrussell/oh-my-zsh#3965.
